### PR TITLE
Fix Instantiating ID's with empty field values

### DIFF
--- a/src/Order/DataType/OrderDeliveryAddress.php
+++ b/src/Order/DataType/OrderDeliveryAddress.php
@@ -122,18 +122,26 @@ final class OrderDeliveryAddress implements AddressInterface, ShopModelAwareInte
         return (string) $this->order->getRawFieldData('oxdelfax');
     }
 
-    public function countryId(): ID
+    public function countryId(): ?ID
     {
-        return new ID(
-            $this->order->getRawFieldData('oxdelcountryid')
-        );
+        $delCountryId = $this->order->getRawFieldData('oxdelcountryid');
+
+        if ($delCountryId) {
+            return new ID($delCountryId);
+        }
+
+        return null;
     }
 
-    public function stateId(): ID
+    public function stateId(): ?ID
     {
-        return new ID(
-            $this->order->getRawFieldData('oxdelstateid')
-        );
+        $stateId = $this->order->getRawFieldData('oxdelstateid');
+        
+        if ($stateId) {
+            return new ID($stateId);
+        }
+        
+        return null;
     }
 
     public static function getModelClass(): string


### PR DESCRIPTION
The database fields for StateID and CountryID can contain null values, in which case any instantiation of a GraphQL ID Type will throw an error. Placing an order with no deliveryAddress attached and querying the returned datatype for it will fail in this case.

This MR fixes the bug.