### PR TITLE
Allow empty oxdelcountryid and oxdelstateid fields in OrderDeliveryAddress

### DIFF
--- a/src/Order/DataType/OrderDeliveryAddress.php
+++ b/src/Order/DataType/OrderDeliveryAddress.php
@@ -122,18 +122,26 @@ final class OrderDeliveryAddress implements AddressInterface, ShopModelAwareInte
         return (string) $this->order->getRawFieldData('oxdelfax');
     }
 
-    public function countryId(): ID
+    public function countryId(): ?ID
     {
-        return new ID(
-            $this->order->getRawFieldData('oxdelcountryid')
-        );
+        $delCountryId = $this->order->getRawFieldData('oxdelcountryid');
+
+        if ($delCountryId) {
+            return new ID($delCountryId);
+        }
+
+        return null;
     }
 
-    public function stateId(): ID
+    public function stateId(): ?ID
     {
-        return new ID(
-            $this->order->getRawFieldData('oxdelstateid')
-        );
+        $stateId = $this->order->getRawFieldData('oxdelstateid');
+
+        if ($stateId) {
+            return new ID($stateId);
+        }
+
+        return null;
     }
 
     public static function getModelClass(): string


### PR DESCRIPTION
Querying the deliveryAddress along with an order when none is set throws an error, because the GraphQL ID constructors in the related methods in the OrderDeliveryAddress class are passed an empty value, which is not allowed.

This pull request fixes this.