### PR TITLE
variant selections for querying and configuring multidimensional variants

### DIFF
--- a/src/Product/Controller/Product.php
+++ b/src/Product/Controller/Product.php
@@ -10,9 +10,11 @@ declare(strict_types=1);
 namespace OxidEsales\GraphQL\Storefront\Product\Controller;
 
 use OxidEsales\GraphQL\Base\DataType\Pagination\Pagination as PaginationFilter;
+use OxidEsales\GraphQL\Base\Exception\InvalidLogin;
 use OxidEsales\GraphQL\Storefront\Product\DataType\Product as ProductDataType;
 use OxidEsales\GraphQL\Storefront\Product\DataType\ProductFilterList;
 use OxidEsales\GraphQL\Storefront\Product\DataType\Sorting;
+use OxidEsales\GraphQL\Storefront\Product\DataType\VariantSelections;
 use OxidEsales\GraphQL\Storefront\Product\Service\Product as ProductService;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 use TheCodingMachine\GraphQLite\Types\ID;
@@ -51,5 +53,21 @@ final class Product
             $pagination,
             $sort ?? Sorting::fromUserInput()
         );
+    }
+
+    /**
+     * @Query()
+     *
+     * @param string $productId
+     * @param ?string[] $varSelids
+     * @return ?VariantSelections
+     * @throws InvalidLogin
+     * @throws ProductNotFound
+     */
+    public function variantSelections(string $productId, ?array $varSelids): ?VariantSelections
+    {
+        $varSelids = (isset($varSelids) && !!count($varSelids)) ? $varSelids : null;
+
+        return $this->productService->variantSelections($productId, $varSelids);
     }
 }

--- a/src/Product/Controller/Product.php
+++ b/src/Product/Controller/Product.php
@@ -61,8 +61,6 @@ final class Product
      * @param string $productId
      * @param ?string[] $varSelids
      * @return ?VariantSelections
-     * @throws InvalidLogin
-     * @throws ProductNotFound
      */
     public function variantSelections(string $productId, ?array $varSelids): ?VariantSelections
     {

--- a/src/Product/DataType/Selection.php
+++ b/src/Product/DataType/Selection.php
@@ -34,6 +34,30 @@ final class Selection
      */
     public function getValue(): string
     {
+        return (string)$this->selection->getValue();
+    }
+
+    /**
+     * @Field()
+     */
+    public function getName(): string
+    {
         return (string)$this->selection->getName();
+    }
+
+    /**
+     * @Field()
+     */
+    public function isActive(): bool
+    {
+        return (bool)$this->selection->isActive();
+    }
+
+    /**
+     * @Field()
+     */
+    public function isDisabled(): bool
+    {
+        return (bool)$this->selection->isDisabled();
     }
 }

--- a/src/Product/DataType/VariantSelectionList.php
+++ b/src/Product/DataType/VariantSelectionList.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\GraphQL\Storefront\Product\DataType;
+
+use OxidEsales\Eshop\Application\Model\VariantSelectList as EshopVariantSelectionListModel;
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\GraphQLite\Types\ID;
+
+/**
+ * @Type()
+ */
+final class VariantSelectionList
+{
+    /** @var EshopVariantSelectionListModel */
+    private EshopVariantSelectionListModel $variantSelectList;
+
+    /**
+     * constructor
+     */
+    public function __construct(EshopVariantSelectionListModel $selectionList)
+    {
+        $this->variantSelectList = $selectionList;
+    }
+
+    /**
+     * @Field()
+     */
+    public function getLabel(): string
+    {
+        return (string) $this->variantSelectList->getLabel();
+    }
+
+    /**
+     *  @Field()
+     */
+    public function getActiveSelection(): ?Selection
+    {
+        if ($activeSelection = $this->variantSelectList->getActiveSelection()) {
+            return new Selection($activeSelection);
+        }
+
+        return null;
+    }
+
+    /**
+     * @Field()
+     *
+     * @return Selection[]
+     */
+    public function getFields(): array
+    {
+        $fields = [];
+
+        foreach ($this->variantSelectList->getSelections() as $field) {
+            $fields[] = new Selection($field);
+        }
+
+        return $fields;
+    }
+}

--- a/src/Product/DataType/VariantSelectionList.php
+++ b/src/Product/DataType/VariantSelectionList.php
@@ -43,6 +43,7 @@ final class VariantSelectionList
      */
     public function getActiveSelection(): ?Selection
     {
+        /** @phpstan-ignore-next-line */
         if ($activeSelection = $this->variantSelectList->getActiveSelection()) {
             return new Selection($activeSelection);
         }

--- a/src/Product/DataType/VariantSelectionList.php
+++ b/src/Product/DataType/VariantSelectionList.php
@@ -43,12 +43,10 @@ final class VariantSelectionList
      */
     public function getActiveSelection(): ?Selection
     {
-        /** @phpstan-ignore-next-line */
-        if ($activeSelection = $this->variantSelectList->getActiveSelection()) {
-            return new Selection($activeSelection); // @phpstan-ignore-line
-        }
+        $activeSelection = $this->variantSelectList->getActiveSelection();
 
-        return null; // @phpstan-ignore-line
+        /** @phpstan-ignore-next-line */
+        return $activeSelection ? new Selection($activeSelection) : null;
     }
 
     /**

--- a/src/Product/DataType/VariantSelectionList.php
+++ b/src/Product/DataType/VariantSelectionList.php
@@ -45,10 +45,10 @@ final class VariantSelectionList
     {
         /** @phpstan-ignore-next-line */
         if ($activeSelection = $this->variantSelectList->getActiveSelection()) {
-            return new Selection($activeSelection);
+            return new Selection($activeSelection); // @phpstan-ignore-line
         }
 
-        return null;
+        return null; // @phpstan-ignore-line
     }
 
     /**

--- a/src/Product/DataType/VariantSelections.php
+++ b/src/Product/DataType/VariantSelections.php
@@ -36,7 +36,7 @@ class VariantSelections
     {
         $variantSelectionList = [];
 
-        if (!isset($this->variantSelections['selections']) || !count($this->variantSelections['selections']) ) {
+        if (!isset($this->variantSelections['selections']) || !count($this->variantSelections['selections'])) {
             return $variantSelectionList;
         }
 

--- a/src/Product/DataType/VariantSelections.php
+++ b/src/Product/DataType/VariantSelections.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+declare(strict_types=1);
+
+namespace OxidEsales\GraphQL\Storefront\Product\DataType;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+
+/**
+ * @Type()
+ */
+class VariantSelections
+{
+    private array $variantSelections;
+
+    /**
+     * @param array $variantSelections
+     */
+    public function __construct(array $variantSelections)
+    {
+        $this->variantSelections = $variantSelections;
+    }
+
+    /**
+     * @Field()
+     *
+     * @return VariantSelectionList[]
+     */
+    public function getSelections(): array
+    {
+        $variantSelectionList = [];
+
+        if (!isset($this->variantSelections['selections']) || !count($this->variantSelections['selections']) ) {
+            return $variantSelectionList;
+        }
+
+        foreach ($this->variantSelections['selections'] as $variantSelection) {
+            $variantSelectionList[] = new VariantSelectionList($variantSelection);
+        }
+
+        return $variantSelectionList;
+    }
+
+    /**
+     * @Field()
+     *
+     * @return ?Product
+     */
+    public function getActiveVariant(): ?Product
+    {
+        if (!isset($this->variantSelections['oActiveVariant'])) {
+            return null;
+        }
+
+        return new Product($this->variantSelections['oActiveVariant']);
+    }
+}

--- a/src/Product/Infrastructure/Product.php
+++ b/src/Product/Infrastructure/Product.php
@@ -18,6 +18,7 @@ use OxidEsales\Eshop\Application\Model\Manufacturer as EshopManufacturerModel;
 use OxidEsales\Eshop\Application\Model\Review as EshopReviewModel;
 use OxidEsales\Eshop\Application\Model\SelectList as EshopSelectionListModel;
 use OxidEsales\Eshop\Application\Model\Vendor as EshopVendorModel;
+use OxidEsales\GraphQL\Base\Exception\NotFound;
 use OxidEsales\GraphQL\Storefront\Manufacturer\DataType\Manufacturer as ManufacturerDataType;
 use OxidEsales\GraphQL\Storefront\Product\DataType\Product as ProductDataType;
 use OxidEsales\GraphQL\Storefront\Product\DataType\ProductAttribute as ProductAttributeDataType;
@@ -32,6 +33,30 @@ use function is_iterable;
 
 final class Product
 {
+    /**
+     * get parent by id. return parent if available, otherwise current article
+     *
+     * @param $id
+     * @return ProductDataType
+     * @throws NotFound
+     */
+    public function getParentById($id): ProductDataType
+    {
+        $article = oxNew(EshopProductModel::class);
+
+        if (!$article->load($id) || !$article->canView()) {
+            throw new NotFound($id);
+        }
+
+        if ($parentId = $article->getFieldData('oxparentid')) {
+            if (!$article->load($parentId) || !$article->canView()) {
+                throw new NotFound($parentId);
+            }
+        }
+
+        return new ProductDataType($article);
+    }
+
     /**
      * @return ProductScalePriceDataType[]
      */

--- a/src/Product/Infrastructure/Product.php
+++ b/src/Product/Infrastructure/Product.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OxidEsales\GraphQL\Storefront\Product\Infrastructure;
 
+use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\Eshop\Application\Model\Article as EshopProductModel;
 use OxidEsales\Eshop\Application\Model\ArticleList as EshopProductListModel;
 use OxidEsales\Eshop\Application\Model\Attribute as EshopAttributeModel;
@@ -49,12 +50,21 @@ final class Product
         }
 
         if ($parentId = $article->getFieldData('oxparentid')) {
-            if (!$article->load($parentId) || !$article->canView()) {
+            if (!$article->load($parentId) || (method_exists($article, 'canView') && !$article->canView())) {
                 throw new NotFound($parentId);
             }
         }
 
         return new ProductDataType($article);
+    }
+
+    /**
+     * @return void
+     */
+    public function setLoadVariants(): void
+    {
+        /** @phpstan-ignore-next-line */
+        Registry::getConfig()->setConfigParam('blLoadVariants', true);
     }
 
     /**

--- a/src/Product/Infrastructure/Product.php
+++ b/src/Product/Infrastructure/Product.php
@@ -36,15 +36,15 @@ final class Product
     /**
      * get parent by id. return parent if available, otherwise current article
      *
-     * @param $id
+     * @param string $id
      * @return ProductDataType
      * @throws NotFound
      */
-    public function getParentById($id): ProductDataType
+    public function getParentById(string $id): ProductDataType
     {
         $article = oxNew(EshopProductModel::class);
 
-        if (!$article->load($id) || !$article->canView()) {
+        if (!$article->load($id) || (method_exists($article, 'canView') && !$article->canView())) {
             throw new NotFound($id);
         }
 

--- a/src/Product/Service/Product.php
+++ b/src/Product/Service/Product.php
@@ -113,8 +113,7 @@ final class Product
 
         Registry::getConfig()->setConfigParam('blLoadVariants', true);
 
-        if ($product->isActive() || $this->authorizationService->isAllowed('VIEW_INACTIVE_PRODUCT'))
-        {
+        if ($product->isActive() || $this->authorizationService->isAllowed('VIEW_INACTIVE_PRODUCT')) {
             if ($variantSelections = $product->getEshopModel()->getVariantSelections($varSelids, $childId)) {
                 return new VariantSelections($variantSelections);
             }

--- a/src/Product/Service/Product.php
+++ b/src/Product/Service/Product.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OxidEsales\GraphQL\Storefront\Product\Service;
 
-use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\GraphQL\Base\DataType\Pagination\Pagination as PaginationFilter;
 use OxidEsales\GraphQL\Base\DataType\Sorting\Sorting as BaseSorting;
 use OxidEsales\GraphQL\Base\Exception\InvalidLogin;
@@ -111,7 +110,7 @@ final class Product
             $childId = $productId;
         }
 
-        Registry::getConfig()->setConfigParam('blLoadVariants', true);
+        $this->productInfrastructure->setLoadVariants();
 
         if ($product->isActive() || $this->authorizationService->isAllowed('VIEW_INACTIVE_PRODUCT')) {
             if ($variantSelections = $product->getEshopModel()->getVariantSelections($varSelids, $childId)) {

--- a/src/Product/Service/Product.php
+++ b/src/Product/Service/Product.php
@@ -9,13 +9,16 @@ declare(strict_types=1);
 
 namespace OxidEsales\GraphQL\Storefront\Product\Service;
 
+use OxidEsales\Eshop\Core\Registry;
 use OxidEsales\GraphQL\Base\DataType\Pagination\Pagination as PaginationFilter;
 use OxidEsales\GraphQL\Base\DataType\Sorting\Sorting as BaseSorting;
 use OxidEsales\GraphQL\Base\Exception\InvalidLogin;
 use OxidEsales\GraphQL\Base\Exception\NotFound;
 use OxidEsales\GraphQL\Storefront\Product\DataType\Product as ProductDataType;
 use OxidEsales\GraphQL\Storefront\Product\DataType\ProductFilterList;
+use OxidEsales\GraphQL\Storefront\Product\DataType\VariantSelections;
 use OxidEsales\GraphQL\Storefront\Product\Exception\ProductNotFound;
+use OxidEsales\GraphQL\Storefront\Product\Infrastructure\Product as ProductInfrastructure;
 use OxidEsales\GraphQL\Storefront\Shared\Infrastructure\Repository;
 use OxidEsales\GraphQL\Storefront\Shared\Service\Authorization;
 use TheCodingMachine\GraphQLite\Types\ID;
@@ -28,12 +31,17 @@ final class Product
     /** @var Authorization */
     private $authorizationService;
 
+    /** @var ProductInfrastructure */
+    private $productInfrastructure;
+
     public function __construct(
         Repository $repository,
-        Authorization $authorizationService
+        Authorization $authorizationService,
+        ProductInfrastructure $productInfrastructure
     ) {
         $this->repository = $repository;
         $this->authorizationService = $authorizationService;
+        $this->productInfrastructure = $productInfrastructure;
     }
 
     /**
@@ -80,5 +88,40 @@ final class Product
             $pagination ?? new PaginationFilter(),
             $sort
         );
+    }
+
+    /**
+     * @param string $productId
+     * @param string[]|null $varSelids
+     * @return ?VariantSelections
+     * @throws InvalidLogin
+     * @throws ProductNotFound
+     */
+    public function variantSelections(string $productId, ?array $varSelids): ?VariantSelections
+    {
+        try {
+            $product = $this->productInfrastructure->getParentById($productId);
+        } catch (NotFound $e) {
+            throw ProductNotFound::byId($productId);
+        }
+
+        $childId = null;
+
+        if ($product->getEshopModel()->getId() !== $productId) {
+            $childId = $productId;
+        }
+
+        Registry::getConfig()->setConfigParam('blLoadVariants', true);
+
+        if ($product->isActive() || $this->authorizationService->isAllowed('VIEW_INACTIVE_PRODUCT'))
+        {
+            if ($variantSelections = $product->getEshopModel()->getVariantSelections($varSelids, $childId)) {
+                return new VariantSelections($variantSelections);
+            }
+
+            return null;
+        }
+
+        throw new InvalidLogin('Unauthorized');
     }
 }


### PR DESCRIPTION
This PR integrates the possibility to query variant selections. While the products' currently implemented `getVariants()` Field is able to display a flat list of all available variants, it's not yet suitable for configuring multidimensional variants, which, according to OXID's core logic, is done through variantselections by querying the appropriate variant selection id's until the user has a final concrete variant to buy. Querying variant selections will therefore output a seperated set of selection lists, split by variant type, to display and configure the final variant.

Some notes:

- I implemented a sperate query, because variant selections are not a property of / related to an article in any way. Feel free to move it anywhere else, though, if you think that's not the appropriate place.
- My PR might break things, as the current `getValue()` getter in the DataType `Selection` returned the selection name, not the value. Since the name also exists, I changed this field to return the value instead of the name of the selection
- In the DataType `getActiveSelection` I had to exclude some stuff from phpstan, since the OXID core is not commented properly for the accessed methods

And sorry for not providing tests for my PR's. Since our production system a.) is not on par with the current b-6.5.x branch and b) we have another testing framework I don't have a running installation with the right testing framework and branch version at hand. I might set that up in the future as I have more PR's coming your way ;)

If you have any issues or feedback please let me know!
Best, Paul