### PR TITLE
src/Vendor is ignored by git on windows systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 tests/.phpunit.result.cache
 .deptrac.cache
 composer.lock
-vendor/
+/vendor/
 tests/reports/


### PR DESCRIPTION
The directory /src/Vendor is ignored by git on Windows-Systems because of the entry "vendor" in the .gitignore-file.